### PR TITLE
Add provides tag to the AppStream metainfo file

### DIFF
--- a/io.github.g0orx.linhpsdr.metainfo.xml
+++ b/io.github.g0orx.linhpsdr.metainfo.xml
@@ -11,6 +11,10 @@
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-3.0-only</project_license>
 
+  <provides>
+    <id>linhpsdr.desktop</id>
+  </provides>
+
   <description>
     <p>
       An HPSDR (High Performance Software Defined Radio) application for controlling HPSDR compatible radios,


### PR DESCRIPTION
Point to the original desktop file name. Useful for grouping together the Flatpak and non-Flatpak packages without rDNS formatted desktop file in GNOME Software / KDE Discover.